### PR TITLE
Fix for null being converted to an empty string

### DIFF
--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -1088,14 +1088,12 @@ class FinancePayment extends PaymentModule
 
         if (!empty(Configuration::get('FINANCE_PLAN_SELECTION'))) {
            return unserialize( Configuration::get('FINANCE_PLAN_SELECTION'));
-        }
-        else{
+        } else {
             $api = new FinanceApi();
             $plans = $api->getCartPlans($cart);
-            if(count($plans) >= 1){
+            if (count($plans) >= 1) {
                 Configuration::updateValue('FINANCE_PLAN_SELECTION', serialize($plans));
-            }
-            else{
+            } else {
                 Configuration::updateValue('FINANCE_PLAN_SELECTION', null);
                 $plans = null;
             }

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -1111,16 +1111,14 @@ class FinancePayment extends PaymentModule
      */
     function getPlans(){
 
-        if ( Configuration::get('FINANCE_PLAN_SELECTION') !== null ) {
+        if (!empty(Configuration::get('FINANCE_PLAN_SELECTION'))) {
             return unserialize( Configuration::get('FINANCE_PLAN_SELECTION'));
-        }
-        else{
+        } else {
             $FinanceApi = new FinanceApi();
             $plans  = $FinanceApi->getPlans();
-            if(count($plans) >= 1){
+            if (count($plans) >= 1) {
                 Configuration::updateValue('FINANCE_PLAN_SELECTION', serialize($plans));
-            }
-            else{
+            } else {
                 Configuration::updateValue('FINANCE_PLAN_SELECTION', null);
                 $plans = null;
             }


### PR DESCRIPTION
Prestashop seems to convert a null value into an empty string, so the module never initially searches for plans after install as it expects null. I've switched null to the empty function, which will work for null anyhow