### PR TITLE
Bug/1.7.4.3 install issue

### DIFF
--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -253,7 +253,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
 
             $data = array(
                 'status'  => false,
-                'message' => Tools::displayError("something went wrong?"),
+                'message' => Tools::displayError($e->getMessage()),
             );
         }
          return $data;

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -203,6 +203,7 @@ class FinancePayment extends PaymentModule
     {
         $order_state = new OrderState();
         $order_state->name = array_fill(0, 10, $name);
+        $order_state->name[$this->context->language->id] = $name;
         $order_state->module_name = $status['module_name'];
         $order_state->send_email = $status['send_email'];
         $order_state->color = $color;

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -202,8 +202,7 @@ class FinancePayment extends PaymentModule
     private function addState($name, $color, $status)
     {
         $order_state = new OrderState();
-        $order_state->name = array();
-        $order_state->name[$this->context->language->id] = $name;
+        $order_state->name = array_fill(0, 10, $name);
         $order_state->module_name = $status['module_name'];
         $order_state->send_email = $status['send_email'];
         $order_state->color = $color;


### PR DESCRIPTION
For some reason my install kept throwing up an error about the state name being empty. Most of the examples of instantiating this class that I have seen have used the _array_fill_ function to attribute the state name to keys 1 to 10. It seemed to do the trick with mine and should have no adverse effects on older presta versions