### PR TITLE
Remove error from products page

### DIFF
--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -159,11 +159,9 @@ class FinanceApi
     {
         $settings = $this->getProductSettings($id_product);
 
+        $product_selection = Configuration::get('FINANCE_PRODUCTS_OPTIONS');
+        $price_threshold   = Configuration::get('FINANCE_PRODUCTS_MINIMUM');
 
-        if ($settings["display"] != "custom") {
-            $product_selection = Configuration::get('FINANCE_PRODUCTS_OPTIONS');
-            $price_threshold   = Configuration::get('FINANCE_PRODUCTS_MINIMUM');
-        }
 
         $plans = $this->getPlans(true);
 
@@ -220,8 +218,8 @@ class FinanceApi
     {
         $array       = explode('_', $key);
         $environment = Tools::strtoupper($array[0]);
-        return ('LIVE' == $environment) 
-            ? constant("Divido\MerchantSDK\Environment::PRODUCTION") 
+        return ('LIVE' == $environment)
+            ? constant("Divido\MerchantSDK\Environment::PRODUCTION")
             : constant("Divido\MerchantSDK\Environment::$environment");
     }
 


### PR DESCRIPTION
"Product selection" = "All products" now overrides custom plans set per product
$product_selection was undefined if $settings["display"] == "custom" trowing an error

