### PR TITLE
fix: switches to UAT calculator if UAT API Key is present

### DIFF
--- a/financepayment/controllers/front/payment.php
+++ b/financepayment/controllers/front/payment.php
@@ -71,9 +71,10 @@ class FinancePaymentPaymentModuleFrontController extends ModuleFrontController
             $lender =  $api->setLender();
         }
 
+        $finance_env = filter_var(Configuration::get('FINANCE_ENVIRONMENT'), FILTER_SANITIZE_STRIPPED);
         $calculator_url = (explode('_', Configuration::get('FINANCE_API_KEY'))[0] === 'user-acceptance-testing') 
-            ? "https://s3.eu-west-1.amazonaws.com/content.divido.com/widget/v3/".Configuration::get('FINANCE_ENVIRONMENT').".uat.calculator.js"
-            : "https://cdn.divido.com/widget/v3/".Configuration::get('FINANCE_ENVIRONMENT').".calculator.js";
+            ? "https://s3.eu-west-1.amazonaws.com/content.divido.com/widget/v3/{$finance_env}.uat.calculator.js"
+            : "https://cdn.divido.com/widget/v3/{$finance_env}.calculator.js";
 
         $this->context->smarty->assign(
             array(

--- a/financepayment/controllers/front/payment.php
+++ b/financepayment/controllers/front/payment.php
@@ -71,11 +71,16 @@ class FinancePaymentPaymentModuleFrontController extends ModuleFrontController
             $lender =  $api->setLender();
         }
 
+        $calculator_url = (explode('_', Configuration::get('FINANCE_API_KEY'))[0] === 'user-acceptance-testing') 
+            ? "https://s3.eu-west-1.amazonaws.com/content.divido.com/widget/v3/".Configuration::get('FINANCE_ENVIRONMENT').".uat.calculator.js"
+            : "https://cdn.divido.com/widget/v3/".Configuration::get('FINANCE_ENVIRONMENT').".calculator.js";
+
         $this->context->smarty->assign(
             array(
                 'payment_error' => $payment_error,
                 'responsetext' => $responsetext,
                 'finance_environment' => Configuration::get('FINANCE_ENVIRONMENT'),
+                'calculator_url' => $calculator_url,
                 'nbProducts' => $cart->nbProducts(),
                 'responsedes' => $responsedes,
                 'cust_currency' => $cart->id_currency,

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -1008,12 +1008,16 @@ class FinancePayment extends PaymentModule
             }
         }
 
+        $calculator_url = (explode('_', Configuration::get('FINANCE_API_KEY'))[0] === 'user-acceptance-testing') 
+            ? "https://s3.eu-west-1.amazonaws.com/content.divido.com/widget/v3/".Configuration::get('FINANCE_ENVIRONMENT').".uat.calculator.js"
+            : "https://cdn.divido.com/widget/v3/".Configuration::get('FINANCE_ENVIRONMENT').".calculator.js";
 
         $this->context->smarty->assign(
             array(
             'plans' => implode(',', array_keys($plans)),
             'raw_total' => $product_price,
             'finance_environment'  => Configuration::get('FINANCE_ENVIRONMENT'),
+            'calculator_url' => $calculator_url,
             'api_key' => Tools::substr(
                 Configuration::get('FINANCE_API_KEY'),
                 0,

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -1008,9 +1008,10 @@ class FinancePayment extends PaymentModule
             }
         }
 
+        $finance_env = filter_var(Configuration::get('FINANCE_ENVIRONMENT'), FILTER_SANITIZE_STRIPPED);
         $calculator_url = (explode('_', Configuration::get('FINANCE_API_KEY'))[0] === 'user-acceptance-testing') 
-            ? "https://s3.eu-west-1.amazonaws.com/content.divido.com/widget/v3/".Configuration::get('FINANCE_ENVIRONMENT').".uat.calculator.js"
-            : "https://cdn.divido.com/widget/v3/".Configuration::get('FINANCE_ENVIRONMENT').".calculator.js";
+            ? "https://s3.eu-west-1.amazonaws.com/content.divido.com/widget/v3/{$finance_env}.uat.calculator.js"
+            : "https://cdn.divido.com/widget/v3/{$finance_env}.calculator.js";
 
         $this->context->smarty->assign(
             array(

--- a/financepayment/views/templates/front/payment_execution.tpl
+++ b/financepayment/views/templates/front/payment_execution.tpl
@@ -53,7 +53,7 @@
         <div data-calculator-widget data-mode="calculator" data-amount="{$raw_total *100|escape:'htmlall':'UTF-8'}" data-plans="{$plans|escape:'htmlall':'UTF-8'}">
     </div>
 {literal}
-    <script type="text/javascript"  src="https://cdn.divido.com/widget/v3/{/literal}{$finance_environment|escape:'htmlall':'UTF-8'}{literal}.calculator.js" ></script>
+    <script type="text/javascript"  src="{/literal}{$calculator_url}{literal}" ></script>
 {/literal}
 <div class="buttons">
     <p class="cart_navigation clearfix">

--- a/financepayment/views/templates/front/payment_execution_1_6.tpl
+++ b/financepayment/views/templates/front/payment_execution_1_6.tpl
@@ -60,7 +60,7 @@
     <div data-calculator-widget data-mode="calculator" data-amount="{$raw_total *100|escape:'htmlall':'UTF-8'}" data-plans="{$plans|escape:'htmlall':'UTF-8'}">
 </div>
 {literal}
-    <script type="text/javascript"  src="https://cdn.divido.com/widget/v3/{/literal}{$finance_environment|escape:'htmlall':'UTF-8'}{literal}.calculator.js" ></script>
+    <script type="text/javascript"  src="{/literal}{$calculator_url}{literal}" ></script>
 {/literal}
 
     <div class="buttons">

--- a/financepayment/views/templates/hook/calculator.tpl
+++ b/financepayment/views/templates/hook/calculator.tpl
@@ -33,5 +33,5 @@
 {/literal}
 <div data-calculator-widget data-amount="{$raw_total*100|escape:'htmlall':'UTF-8'}"  data-plans="{$plans|escape:'htmlall':'UTF-8'}"></div>
 {literal}
-    <script type="text/javascript"  src="https://cdn.divido.com/widget/v3/{/literal}{$finance_environment|escape:'htmlall':'UTF-8'}{literal}.calculator.js" ></script>
+    <script type="text/javascript"  src="{/literal}{$calculator_url}{literal}" ></script>
 {/literal}

--- a/financepayment/views/templates/hook/widget.tpl
+++ b/financepayment/views/templates/hook/widget.tpl
@@ -45,7 +45,7 @@
     {if $data_language}data-language="{$data_language}"{/if}
 ></div>
 {literal}
-    <script type="text/javascript"  src="https://cdn.divido.com/widget/v3/{/literal}{$finance_environment|escape:'htmlall':'UTF-8'}{literal}.calculator.js" ></script>
+    <script type="text/javascript"  src="{/literal}{$calculator_url}{literal}" ></script>
 {/literal}
 
 


### PR DESCRIPTION
Something to be aware of in single tenancy currently:

The calculator has a hard-coded environment var link to its graphql-api, meaning UAT API Keys search for the merchant on prod graphql-api, resulting in an error as no merchant is found. To work around this, another copy of the calculator code has been created for UAT with the UAT graphql-api baked in.

This code switches to the UAT graphql if a UAT API key is present