### PR TITLE
feat:mer-38 calculator url routing

### DIFF
--- a/financepayment/.gitignore
+++ b/financepayment/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /vendor
+.php_cs.cache

--- a/financepayment/classes/DividoHelper.php
+++ b/financepayment/classes/DividoHelper.php
@@ -7,7 +7,7 @@ use Divido\MerchantSDK\Environment;
 class DividoHelper{
 
     const CALCULATOR_URL = "//cdn.divido.com/widget/v3/";
-    const VERSION = "2.4.2";
+    const PLUGIN_VERSION = "2.4.2";
 
     public static function generateCalcUrl($tenant, $environment){
         
@@ -18,8 +18,8 @@ class DividoHelper{
         return sprintf("%s%s.calculator.js", self::CALCULATOR_URL, implode(".",$prefixes));
     }
 
-    public static function getVersion() {
-        return self::VERSION;
+    public static function getPluginVersion() {
+        return self::PLUGIN_VERSION;
     }
 
 }

--- a/financepayment/classes/DividoHelper.php
+++ b/financepayment/classes/DividoHelper.php
@@ -7,6 +7,7 @@ use Divido\MerchantSDK\Environment;
 class DividoHelper{
 
     const CALCULATOR_URL = "//cdn.divido.com/widget/v3/";
+    const VERSION = "2.4.2";
 
     public static function generateCalcUrl($tenant, $environment){
         
@@ -15,6 +16,10 @@ class DividoHelper{
             $prefixes[] = $environment;
         }
         return sprintf("%s%s.calculator.js", self::CALCULATOR_URL, implode(".",$prefixes));
+    }
+
+    public static function getVersion() {
+        return self::VERSION;
     }
 
 }

--- a/financepayment/classes/DividoHelper.php
+++ b/financepayment/classes/DividoHelper.php
@@ -1,25 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Divido\Helper;
 
 use Divido\MerchantSDK\Environment;
 
-class DividoHelper{
-
+class DividoHelper
+{
     const CALCULATOR_URL = "//cdn.divido.com/widget/v3/";
+
     const PLUGIN_VERSION = "2.4.2";
 
     public static function generateCalcUrl($tenant, $environment){
-        
+
         $prefixes = [$tenant];
         if($environment !== Environment::PRODUCTION){
             $prefixes[] = $environment;
         }
-        return sprintf("%s%s.calculator.js", self::CALCULATOR_URL, implode(".",$prefixes));
+
+        return sprintf("%s%s.calculator.js", self::CALCULATOR_URL, implode(".", $prefixes));
     }
 
     public static function getPluginVersion() {
         return self::PLUGIN_VERSION;
     }
-
 }

--- a/financepayment/classes/DividoHelper.php
+++ b/financepayment/classes/DividoHelper.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Divido\Helper;
+
+use Divido\MerchantSDK\Environment;
+
+class DividoHelper{
+
+    const CALCULATOR_URL = "//cdn.divido.com/widget/v3/";
+
+    public static function generateCalcUrl($tenant, $environment){
+        
+        $prefixes = [$tenant];
+        if($environment !== Environment::PRODUCTION){
+            $prefixes[] = $environment;
+        }
+        return sprintf("%s%s.calculator.js", self::CALCULATOR_URL, implode(".",$prefixes));
+    }
+
+}

--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -49,7 +49,7 @@ class EnvironmentUrlException extends \Exception
  **/
 class Merchant_SDK
 {
-    private static Client $instance = null;
+    private static Client $instance;
     /**
      * Creates and returns a merchant sdk instance
      *
@@ -60,7 +60,7 @@ class Merchant_SDK
      */
     public static function getSDK($url, $api_key)
     {
-        if(self::$instance === null){
+        if(empty(self::$instance)){
             $env = Environment::getEnvironmentFromAPIKey($api_key);
             $client = new Guzzle();
             $httpClientWrapper = new HttpClientWrapper(
@@ -134,7 +134,7 @@ class FinanceApi
         $environment_url = Configuration::get('FINANCE_ENVIRONMENT_URL');
 
         if (!$environment_url || !$api_key) {
-            return array();
+            return null;
         }
 
         $sdk = Merchant_SDK::getSDK($environment_url, $api_key);

--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -77,7 +77,6 @@ class Merchant_SDK
 }
 class FinanceApi
 {
-
     public function checkEnviromentHealth()
     {
         $environment_url = Configuration::get('FINANCE_ENVIRONMENT_URL');

--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -27,7 +27,6 @@
 namespace Divido\Proxy;
 
 use Configuration;
-use Tools;
 use Db;
 use Divido\MerchantSDK\Client;
 use Divido\MerchantSDK\Environment;

--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -49,6 +49,7 @@ class EnvironmentUrlException extends \Exception
  **/
 class Merchant_SDK
 {
+    private static Client $instance = null;
     /**
      * Creates and returns a merchant sdk instance
      *
@@ -59,20 +60,24 @@ class Merchant_SDK
      */
     public static function getSDK($url, $api_key)
     {
+        if(self::$instance === null){
+            $env = Environment::getEnvironmentFromAPIKey($api_key);
+            $client = new Guzzle();
+            $httpClientWrapper = new HttpClientWrapper(
+                new GuzzleAdapter($client),
+                $url,
+                $api_key
+            );
 
-        $env = Environment::getEnvironmentFromAPIKey($api_key);
-        $client = new Guzzle();
-        $httpClientWrapper = new HttpClientWrapper(
-            new GuzzleAdapter($client),
-            $url,
-            $api_key
-        );
+            self::$instance = new Client($httpClientWrapper, $env);
+        }
 
-        return new Client($httpClientWrapper, $env);
+        return self::$instance;
     }
 }
 class FinanceApi
 {
+
     public function checkEnviromentHealth()
     {
         $environment_url = Configuration::get('FINANCE_ENVIRONMENT_URL');

--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -24,17 +24,22 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
+namespace Divido\Proxy;
+
+use Configuration;
+use Tools;
+use Db;
 use Divido\MerchantSDK\Client;
 use Divido\MerchantSDK\Environment;
 use Divido\MerchantSDK\Exceptions\MerchantApiBadResponseException;
 use Divido\MerchantSDK\HttpClient\HttpClientWrapper;
 use Divido\MerchantSDKGuzzle5\GuzzleAdapter;
 use GuzzleHttp\Client as Guzzle;
-class EnvironmentUnhealthyException extends Exception
+class EnvironmentUnhealthyException extends \Exception
 {
 }
 
-class EnvironmentUrlException extends Exception
+class EnvironmentUrlException extends \Exception
 {
 }
 
@@ -161,7 +166,7 @@ class FinanceApi
 
             $plans_plain = array();
             foreach ($plans as $plan) {
-                $plan_copy = new stdClass();
+                $plan_copy = new \stdClass();
                 $plan_copy->id = $plan->id;
                 $plan_copy->text = $plan->description;
                 $plan_copy->country = $plan->country;
@@ -263,16 +268,6 @@ class FinanceApi
         $query = "select * from `"._DB_PREFIX_."finance_product` where id_product = '".(int) $id_product."'";
 
         return Db::getInstance()->getRow($query);
-    }
-
-    public function getEnvironment($key)
-    {
-        $array       = explode('_', $key);
-        $environment = Tools::strtoupper($array[0]);
-
-        return ('LIVE' == $environment)
-            ? constant("Divido\MerchantSDK\Environment::PRODUCTION")
-            : constant("Divido\MerchantSDK\Environment::$environment");
     }
 
     public function setLender()

--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
 * 2007-2018 PrestaShop
 *
@@ -50,6 +52,7 @@ class EnvironmentUrlException extends \Exception
 class Merchant_SDK
 {
     private static Client $instance;
+
     /**
      * Creates and returns a merchant sdk instance
      *
@@ -212,7 +215,8 @@ class FinanceApi
     {
         if ($default_plans) {
             return $this->getGlobalSelectedPlans();
-        } 
+        }
+ 
         return $this->getAllPlans();
     }
 

--- a/financepayment/classes/index.php
+++ b/financepayment/classes/index.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
 * 2007-2018 PrestaShop
 *

--- a/financepayment/config.xml
+++ b/financepayment/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>financepayment</name>
     <displayName><![CDATA[Powered by Divido]]></displayName>
-    <version><![CDATA[2.3.0]]></version>
+    <version><![CDATA[2.4.2]]></version>
     <description><![CDATA[The Finance extension allows you to accept finance payments in your Prestashop store.]]></description>
     <author><![CDATA[Divido Financial Services Ltd]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/financepayment/config_fr.xml
+++ b/financepayment/config_fr.xml
@@ -2,7 +2,7 @@
 <module>
     <name>financepayment</name>
     <displayName><![CDATA[Payer par les finances]]></displayName>
-    <version><![CDATA[2.3.0]]></version>
+    <version><![CDATA[2.4.2]]></version>
     <description><![CDATA[Cette extension vous permet d&#039;accepter des paiements de financement dans votre magasin.]]></description>
     <author><![CDATA[Divido Financial Services Ltd]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/financepayment/config_gb.xml
+++ b/financepayment/config_gb.xml
@@ -2,7 +2,7 @@
 <module>
     <name>financepayment</name>
     <displayName><![CDATA[Powered By Divido]]></displayName>
-    <version><![CDATA[2.3.0]]></version>
+    <version><![CDATA[2.4.2]]></version>
     <description><![CDATA[]]></description>
     <author><![CDATA[Divido Financial Services Ltd]]></author>
     <tab><![CDATA[payments_gateways]]></tab>

--- a/financepayment/controllers/front/confirmation.php
+++ b/financepayment/controllers/front/confirmation.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
 * 2007-2018 PrestaShop
 *

--- a/financepayment/controllers/front/index.php
+++ b/financepayment/controllers/front/index.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
 * 2007-2015 PrestaShop
 *

--- a/financepayment/controllers/front/payment.php
+++ b/financepayment/controllers/front/payment.php
@@ -24,6 +24,10 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
+use Divido\Proxy\FinanceApi;
+use Divido\Helper\DividoHelper;
+use Divido\MerchantSDK\Environment;
+
 class FinancePaymentPaymentModuleFrontController extends ModuleFrontController
 {
     public $ssl = true;
@@ -90,7 +94,11 @@ class FinancePaymentPaymentModuleFrontController extends ModuleFrontController
                     0,
                     strpos(Configuration::get('FINANCE_API_KEY'), ".")
                 ),
-                'lender' => $lender
+                'lender' => $lender,
+                'calculator_url' => DividoHelper::generateCalcUrl(
+                    configuration::get('FINANCE_ENVIRONMENT'),
+                    Environment::getEnvironmentFromAPIKey(Configuration::get('FINANCE_API_KEY'))
+                )
             )
         );
         Media::addJsDef(

--- a/financepayment/controllers/front/payment.php
+++ b/financepayment/controllers/front/payment.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
 * 2007-2018 PrestaShop
 *
@@ -24,9 +26,9 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-use Divido\Proxy\FinanceApi;
 use Divido\Helper\DividoHelper;
 use Divido\MerchantSDK\Environment;
+use Divido\Proxy\FinanceApi;
 
 class FinancePaymentPaymentModuleFrontController extends ModuleFrontController
 {

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
 * 2007-2018 PrestaShop
 *

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -24,6 +24,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
+use Divido\Helper\DividoHelper;
 use Divido\Proxy\Merchant_SDK;
 
 class FinancePaymentValidationModuleFrontController extends ModuleFrontController
@@ -31,17 +32,11 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
     const DEBUG_MODE = false;
 
     /**
-     * @var
-     */
-    private $plugin_version;
-
-    /**
      * This class should be use by your Instant Payment
      * Notification system to validate the order remotely
      */
     public function postProcess()
     {
-        $this->plugin_version = "2.2.2";
 
         if (!(Tools::getIsset('total') && Tools::getIsset('deposit') && Tools::getIsset('finance'))) {
             Tools::redirect($this->context->link->getPageLink('index'));
@@ -238,7 +233,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
                 'ecom_platform' => 'prestashop',
                 'ecom_platform_version' => _PS_VERSION_,
                 'ecom_base_url'   => htmlspecialchars_decode($checkout_url),
-                'plugin_version'  => $this->plugin_version,
+                'plugin_version'  => DividoHelper::getVersion(),
                 'merchant_reference' => $cart_id
             )
         );

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -233,7 +233,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
                 'ecom_platform' => 'prestashop',
                 'ecom_platform_version' => _PS_VERSION_,
                 'ecom_base_url'   => htmlspecialchars_decode($checkout_url),
-                'plugin_version'  => DividoHelper::getVersion(),
+                'plugin_version'  => DividoHelper::getPluginVersion(),
                 'merchant_reference' => $cart_id
             )
         );

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -24,12 +24,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-use Divido\Proxy\FinanceApi;
-use Divido\MerchantSDK\Client;
-use Divido\MerchantSDK\Environment;
-use Divido\MerchantSDK\HttpClient\HttpClientWrapper;
-use Divido\MerchantSDKGuzzle5\GuzzleAdapter;
-use GuzzleHttp\Client as Guzzle;
+use Divido\Proxy\Merchant_SDK;
 
 class FinancePaymentValidationModuleFrontController extends ModuleFrontController
 {
@@ -239,15 +234,8 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
             )
         );
 //Note: If creating an application on a merchant with a shared secret, you will have to pass in a valid hmac
-                $env = FinanceApi::getEnvironment($api_key);
-                $client = new Guzzle();
-                $httpClientWrapper = new HttpClientWrapper(
-                    new GuzzleAdapter($client),
-                    Environment::CONFIGURATION[$env]['base_uri'],
-                    $api_key
-                );
 
-                $sdk = new Client($httpClientWrapper, $env);
+                $sdk = Merchant_SDK::getSDK(Configuration::get('FINANCE_ENVIRONMENT_URL'), $api_key);
 
                 $response = $sdk->applications()->createApplication(
                     $application,

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
 * 2007-2018 PrestaShop
 *
@@ -239,15 +241,15 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
                 'merchant_reference' => $cart_id
             )
         );
-//Note: If creating an application on a merchant with a shared secret, you will have to pass in a valid hmac
+        //Note: If creating an application on a merchant with a shared secret, you will have to pass in a valid hmac
 
-                $sdk = Merchant_SDK::getSDK(Configuration::get('FINANCE_ENVIRONMENT_URL'), $api_key);
+        $sdk = Merchant_SDK::getSDK(Configuration::get('FINANCE_ENVIRONMENT_URL'), $api_key);
 
-                $response = $sdk->applications()->createApplication(
-                    $application,
-                    array(),
-                    array ('Content-Type' => 'application/json')
-                );
+        $response = $sdk->applications()->createApplication(
+            $application,
+            array(),
+            array ('Content-Type' => 'application/json')
+        );
 
         try {
                 $application_response_body = $response->getBody()->getContents();
@@ -573,7 +575,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
                     );
                     $order->total_shipping = $order->total_shipping_tax_incl;
 
-                    if (!is_null($carrier) && Validate::isLoadedObject($carrier)) {
+                    if (null !== $carrier && Validate::isLoadedObject($carrier)) {
                         $order->carrier_tax_rate = $carrier->getTaxesRate(
                             new Address(
                                 (int) $this->context->cart->{Configuration::get('PS_TAX_ADDRESS_TYPE')}
@@ -703,7 +705,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
                     }
 
                     // Adding an entry in order_carrier table
-                    if (!is_null($carrier)) {
+                    if (null !== $carrier) {
                         $order_carrier = new OrderCarrier();
                         $order_carrier->id_order = (int) $order->id;
                         $order_carrier->id_carrier = (int) $id_carrier;

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -157,6 +157,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
         }
 
         $discount = round((float) $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS), 2);
+        // If there is a discount, add that as a separate product
         if($discount > 0){
             $products[] = array(
                 'name'     => 'Discount',

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -138,29 +138,38 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
 
         $products  = array();
         foreach ($cart->getProducts() as $product) {
+            $reference = (empty($product['reference'])) ? $product['id_product'] : $product['reference'];
             $products[] = array(
 
-                'name' => $product['name'],
+                'name'     => $product['name'],
                 'quantity' => $product['quantity'],
-                'price' => (int) ($product['price_wt']*100),
+                'price'    => (int) ($product['price_wt']*100),
+                'sku'      => $reference
             );
         }
 
         $sub_total = round((float) $cart->getOrderTotal(true, Cart::BOTH), 2);
+
         $shiphandle = round((float) $cart->getOrderTotal(true, Cart::ONLY_SHIPPING), 2);
+        if($shiphandle > 0){
+            $products[] = array(
+                'name'     => 'Shipping & Handling',
+                'quantity' => 1,
+                'price'    => $shiphandle*100,
+                'sku'      => 'SHPNG'
+            );
+        }
+
         $discount = round((float) $cart->getOrderTotal(true, Cart::ONLY_DISCOUNTS), 2);
+        if($discount > 0){
+            $products[] = array(
+                'name'     => 'Discount',
+                'quantity' => 1,
+                'price'    => -$discount*100,
+                'sku'      => 'DISCNT'
+            );
+        }
 
-        $products[] = array(
-            'name'     => 'Shipping & Handling',
-            'quantity' => 1,
-            'price'    => $shiphandle*100,
-        );
-
-        $products[] = array(
-            'name'     => 'Discount',
-            'quantity' => 1,
-            'price'    => -$discount*100,
-        );
         $response_url = $this->context->link->getModuleLink($this->module->name, 'response');
         $redirect_url = $this->context->link->getModuleLink(
             $this->module->name,

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -24,6 +24,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
+use Divido\Proxy\FinanceApi;
 use Divido\MerchantSDK\Client;
 use Divido\MerchantSDK\Environment;
 use Divido\MerchantSDK\HttpClient\HttpClientWrapper;

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -146,6 +146,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
         $sub_total = round((float) $cart->getOrderTotal(true, Cart::BOTH), 2);
 
         $shiphandle = round((float) $cart->getOrderTotal(true, Cart::ONLY_SHIPPING), 2);
+        // If shopping and handling fee is above 0, add that as a separate product
         if($shiphandle > 0){
             $products[] = array(
                 'name'     => 'Shipping & Handling',

--- a/financepayment/controllers/index.php
+++ b/financepayment/controllers/index.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
 * 2007-2015 PrestaShop
 *

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -35,12 +35,11 @@ require_once dirname(__FILE__) . '/classes/DividoHelper.php';
 use Divido\MerchantSDK\Environment;
 use Divido\MerchantSDK\Exceptions\InvalidApiKeyFormatException;
 use Divido\MerchantSDK\Exceptions\InvalidEnvironmentException;
-use Divido\MerchantSDK\HttpClient\HttpClientWrapper;
-use Divido\MerchantSDKGuzzle5\GuzzleAdapter;
 use Divido\Helper\DividoHelper;
 use Divido\Proxy\FinanceApi;
 use Divido\Proxy\EnvironmentUnhealthyException;
 use Divido\Proxy\EnvironmentUrlException;
+use Divido\Proxy\Merchant_SDK;
 
 class NoFinancePlansException extends Exception
 {
@@ -1151,15 +1150,8 @@ class FinancePayment extends PaymentModule
             ->withDeliveryMethod($shipping_method)
             ->withTrackingNumber($tracking_numbers);
         // Create a new activation for the application.
-        $env = Environment::getEnvironmentFromAPIKey($api_key);
-        $client = new \GuzzleHttp\Client();
-        $httpClientWrapper = new HttpClientWrapper(
-            new GuzzleAdapter($client),
-            Environment::CONFIGURATION[$env]['base_uri'],
-            $api_key
-        );
-        $sdk                      = new \Divido\MerchantSDK\Client($httpClientWrapper, $env);
-        $response                 = $sdk->applicationActivations()->createApplicationActivation(
+        $sdk = Merchant_SDK::getSDK(Configuration::get('FINANCE_ENVIRONMENT_URL'), $api_key);
+        $response = $sdk->applicationActivations()->createApplicationActivation(
             $application,
             $application_activation
         );
@@ -1195,14 +1187,7 @@ class FinancePayment extends PaymentModule
         $applicationCancel = ( new \Divido\MerchantSDK\Models\ApplicationCancellation() )
             ->withOrderItems($items);
         // Create a new activation for the application.
-        $env                      = Environment::getEnvironmentFromAPIKey($api_key);
-        $client                   = new \GuzzleHttp\Client();
-        $httpClientWrapper        = new HttpClientWrapper(
-            new GuzzleAdapter($client),
-            Environment::CONFIGURATION[$env]['base_uri'],
-            $api_key
-        );
-        $sdk = new \Divido\MerchantSDK\Client($httpClientWrapper, $env);
+        $sdk = Merchant_SDK::getSDK(Configuration::get('FINANCE_ENVIRONMENT_URL'), $api_key);
         $response = $sdk->applicationCancellations()->createApplicationCancellation($application, $applicationCancel);
         $cancellation_response_body = $response->getBody()->getContents();
 
@@ -1235,15 +1220,8 @@ class FinancePayment extends PaymentModule
         $applicationRefund = ( new \Divido\MerchantSDK\Models\ApplicationRefund() )
             ->withOrderItems($items);
         // Create a new activation for the application.
-        $env                      = Environment::getEnvironmentFromAPIKey($api_key);
-        $client                   = new \GuzzleHttp\Client();
-        $httpClientWrapper        = new HttpClientWrapper(
-            new GuzzleAdapter($client),
-            Environment::CONFIGURATION[$env]['base_uri'],
-            $api_key
-        );
 
-        $sdk = new \Divido\MerchantSDK\Client($httpClientWrapper, $env);
+        $sdk = Merchant_SDK::getSDK(Configuration::get('FINANCE_ENVIRONMENT_URL'), $api_key);
         $response = $sdk->applicationRefunds()->createApplicationRefund($application, $applicationRefund);
         $cancellation_response_body = $response->getBody()->getContents();
 

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -95,7 +95,7 @@ class FinancePayment extends PaymentModule
     {
         $this->name = 'financepayment';
         $this->tab = 'payments_gateways';
-        $this->version = '2.4.1';
+        $this->version = DividoHelper::getVersion();
         $this->author = 'Divido Financial Services Ltd';
         $this->need_instance = 0;
         $this->module_key = "71b50f7f5d75c244cd0a5635f664cd56";

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -95,7 +95,7 @@ class FinancePayment extends PaymentModule
     {
         $this->name = 'financepayment';
         $this->tab = 'payments_gateways';
-        $this->version = DividoHelper::getVersion();
+        $this->version = DividoHelper::getPluginVersion();
         $this->author = 'Divido Financial Services Ltd';
         $this->need_instance = 0;
         $this->module_key = "71b50f7f5d75c244cd0a5635f664cd56";

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -30,12 +30,17 @@ if (!defined('_PS_VERSION_')) {
 
 require_once dirname(__FILE__) . '/vendor/autoload.php';
 require_once dirname(__FILE__) . '/classes/divido.class.php';
+require_once dirname(__FILE__) . '/classes/DividoHelper.php';
 
 use Divido\MerchantSDK\Environment;
 use Divido\MerchantSDK\Exceptions\InvalidApiKeyFormatException;
 use Divido\MerchantSDK\Exceptions\InvalidEnvironmentException;
 use Divido\MerchantSDK\HttpClient\HttpClientWrapper;
 use Divido\MerchantSDKGuzzle5\GuzzleAdapter;
+use Divido\Helper\DividoHelper;
+use Divido\Proxy\FinanceApi;
+use Divido\Proxy\EnvironmentUnhealthyException;
+use Divido\Proxy\EnvironmentUrlException;
 
 class NoFinancePlansException extends Exception
 {
@@ -1095,23 +1100,21 @@ class FinancePayment extends PaymentModule
             }
         }
 
-        $this->context->smarty->assign(
-            array(
+        $this->context->smarty->assign(array(
             'plans' => implode(',', array_keys($plans)),
             'raw_total' => $product_price,
             'finance_environment'  => Configuration::get('FINANCE_ENVIRONMENT'),
-            'api_key' => Tools::substr(
-                Configuration::get('FINANCE_API_KEY'),
-                0,
-                strpos(Configuration::get('FINANCE_API_KEY'), ".")
-            ),
+            'api_key' => explode(".", Configuration::get('FINANCE_API_KEY'), 2)[0],
             'lender' => $lender,
             'data_button_text' => $data_button_text,
             'data_mode' => $data_mode,
             'data_footnote' => $data_footnote,
-            'data_language' => $data_language
+            'data_language' => $data_language,
+            'calculator_url' => DividoHelper::generateCalcUrl(
+                configuration::get('FINANCE_ENVIRONMENT'),
+                Environment::getEnvironmentFromAPIKey(Configuration::get('FINANCE_API_KEY'))
             )
-        );
+        ));
 
         return $this->display(__FILE__, $template);
     }

--- a/financepayment/translations/da.php
+++ b/financepayment/translations/da.php
@@ -67,6 +67,7 @@ $_MODULE['<{financepayment}prestashop>financepayment_a302a18c80829f5f54c37f836ff
 $_MODULE['<{financepayment}prestashop>financepayment_1f15f53944b9e15a9e66b595b3adeae0'] = 'Noget kan være galt med miljøet. Det vendte tilbage:';
 $_MODULE['<{financepayment}prestashop>financepayment_72e8066cf63a282ccb97f08481969192'] = 'Ugyldig kombination af miljø -URL og API -nøgle. Kontroller værdierne.';
 $_MODULE['<{financepayment}prestashop>financepayment_99d26adcf34fbba8c3926e77563ce8fb'] = 'Skal have mindst en finansieringsplan.';
+$_MODULE['<{financepayment}prestashop>financepayment_04b7971579897c9561ddc3fcb7114358'] = 'En miljø-URL kan være påkrævet for at bruge denne API-nøgle';
 $_MODULE['<{financepayment}prestashop>payment_execution_6a88abffa95f951cdf12db5456ba23c2'] = 'Din kurv ser ud til at være tom';
 $_MODULE['<{financepayment}prestashop>payment_execution_75d8c6fe3d14cb7257e5ce9a5d3f8491'] = 'Fejl';
 $_MODULE['<{financepayment}prestashop>payment_execution_973a684991d48c2119c99f099ee14f86'] = 'Bekræfte';

--- a/financepayment/translations/de.php
+++ b/financepayment/translations/de.php
@@ -67,6 +67,7 @@ $_MODULE['<{financepayment}prestashop>financepayment_a302a18c80829f5f54c37f836ff
 $_MODULE['<{financepayment}prestashop>financepayment_1f15f53944b9e15a9e66b595b3adeae0'] = 'Möglicherweise stimmt etwas mit der Umgebung nicht. Es kam zurück:';
 $_MODULE['<{financepayment}prestashop>financepayment_72e8066cf63a282ccb97f08481969192'] = 'Ungültige Kombination aus Umgebungs-URL und API-Schlüssel. Bitte überprüfen Sie die Werte.';
 $_MODULE['<{financepayment}prestashop>financepayment_99d26adcf34fbba8c3926e77563ce8fb'] = 'Muss mindestens einen Finanzplan haben.';
+$_MODULE['<{financepayment}prestashop>financepayment_04b7971579897c9561ddc3fcb7114358'] = 'Zur Verwendung dieses API-Schlüssels ist möglicherweise eine Umgebungs-URL erforderlich';
 $_MODULE['<{financepayment}prestashop>payment_execution_6a88abffa95f951cdf12db5456ba23c2'] = 'Ihr Warenkorb scheint leer zu sein';
 $_MODULE['<{financepayment}prestashop>payment_execution_75d8c6fe3d14cb7257e5ce9a5d3f8491'] = 'Error';
 $_MODULE['<{financepayment}prestashop>payment_execution_973a684991d48c2119c99f099ee14f86'] = 'Bestätigen';

--- a/financepayment/translations/en.php
+++ b/financepayment/translations/en.php
@@ -67,6 +67,7 @@ $_MODULE['<{financepayment}prestashop>financepayment_a302a18c80829f5f54c37f836ff
 $_MODULE['<{financepayment}prestashop>financepayment_1f15f53944b9e15a9e66b595b3adeae0'] = 'Something may be wrong with the environment. It returned:';
 $_MODULE['<{financepayment}prestashop>financepayment_72e8066cf63a282ccb97f08481969192'] = 'Invalid combination of Environment URL and API key. Please check the values.';
 $_MODULE['<{financepayment}prestashop>financepayment_99d26adcf34fbba8c3926e77563ce8fb'] = 'Must have at least one finance plan.';
+$_MODULE['<{financepayment}prestashop>financepayment_04b7971579897c9561ddc3fcb7114358'] = 'An Environment URL may be required to use this API Key';
 $_MODULE['<{financepayment}prestashop>payment_execution_6a88abffa95f951cdf12db5456ba23c2'] = 'Your cart appears to be empty';
 $_MODULE['<{financepayment}prestashop>payment_execution_75d8c6fe3d14cb7257e5ce9a5d3f8491'] = 'Error';
 $_MODULE['<{financepayment}prestashop>payment_execution_973a684991d48c2119c99f099ee14f86'] = 'Confirm';

--- a/financepayment/translations/es.php
+++ b/financepayment/translations/es.php
@@ -67,6 +67,7 @@ $_MODULE['<{financepayment}prestashop>financepayment_a302a18c80829f5f54c37f836ff
 $_MODULE['<{financepayment}prestashop>financepayment_1f15f53944b9e15a9e66b595b3adeae0'] = 'Algo puede estar mal con el medio ambiente. Regresó:';
 $_MODULE['<{financepayment}prestashop>financepayment_72e8066cf63a282ccb97f08481969192'] = 'Combinación no válida de URL de entorno y clave API. Compruebe los valores.';
 $_MODULE['<{financepayment}prestashop>financepayment_99d26adcf34fbba8c3926e77563ce8fb'] = 'Debe tener al menos un plan financiero.';
+$_MODULE['<{financepayment}prestashop>financepayment_04b7971579897c9561ddc3fcb7114358'] = 'Es posible que se requiera una URL de entorno para usar esta clave de API';
 $_MODULE['<{financepayment}prestashop>payment_execution_6a88abffa95f951cdf12db5456ba23c2'] = 'Tu carrito parece estar vacío';
 $_MODULE['<{financepayment}prestashop>payment_execution_75d8c6fe3d14cb7257e5ce9a5d3f8491'] = 'Error';
 $_MODULE['<{financepayment}prestashop>payment_execution_973a684991d48c2119c99f099ee14f86'] = 'Confirmar';

--- a/financepayment/translations/fr.php
+++ b/financepayment/translations/fr.php
@@ -67,6 +67,7 @@ $_MODULE['<{financepayment}prestashop>financepayment_a302a18c80829f5f54c37f836ff
 $_MODULE['<{financepayment}prestashop>financepayment_1f15f53944b9e15a9e66b595b3adeae0'] = 'Quelque chose ne va pas avec l\'environnement. Il est revenu :';
 $_MODULE['<{financepayment}prestashop>financepayment_72e8066cf63a282ccb97f08481969192'] = 'Combinaison incorrecte d\'URL d\'environnement et de clé API. Veuillez vérifier les valeurs.';
 $_MODULE['<{financepayment}prestashop>financepayment_99d26adcf34fbba8c3926e77563ce8fb'] = 'Doit avoir au moins un plan de financement.';
+$_MODULE['<{financepayment}prestashop>financepayment_04b7971579897c9561ddc3fcb7114358'] = 'Une URL d\'environnement peut être requise pour utiliser cette clé API';
 $_MODULE['<{financepayment}prestashop>payment_execution_6a88abffa95f951cdf12db5456ba23c2'] = 'Votre panier semble être vide';
 $_MODULE['<{financepayment}prestashop>payment_execution_75d8c6fe3d14cb7257e5ce9a5d3f8491'] = 'Erreur';
 $_MODULE['<{financepayment}prestashop>payment_execution_973a684991d48c2119c99f099ee14f86'] = 'Confirmer';

--- a/financepayment/translations/gb.php
+++ b/financepayment/translations/gb.php
@@ -67,6 +67,7 @@ $_MODULE['<{financepayment}prestashop>financepayment_a302a18c80829f5f54c37f836ff
 $_MODULE['<{financepayment}prestashop>financepayment_1f15f53944b9e15a9e66b595b3adeae0'] = 'Something may be wrong with the environment. It returned:';
 $_MODULE['<{financepayment}prestashop>financepayment_72e8066cf63a282ccb97f08481969192'] = 'Invalid combination of Environment URL and API key. Please check the values.';
 $_MODULE['<{financepayment}prestashop>financepayment_99d26adcf34fbba8c3926e77563ce8fb'] = 'Must have at least one finance plan.';
+$_MODULE['<{financepayment}prestashop>financepayment_04b7971579897c9561ddc3fcb7114358'] = 'An Environment URL may be required to use this API Key';
 $_MODULE['<{financepayment}prestashop>payment_execution_6a88abffa95f951cdf12db5456ba23c2'] = 'Your cart appears to be empty';
 $_MODULE['<{financepayment}prestashop>payment_execution_75d8c6fe3d14cb7257e5ce9a5d3f8491'] = 'Error';
 $_MODULE['<{financepayment}prestashop>payment_execution_973a684991d48c2119c99f099ee14f86'] = 'Confirm';

--- a/financepayment/views/templates/front/payment_execution.tpl
+++ b/financepayment/views/templates/front/payment_execution.tpl
@@ -53,7 +53,7 @@
         <div data-calculator-widget data-mode="calculator" data-amount="{$raw_total *100|escape:'htmlall':'UTF-8'}" data-plans="{$plans|escape:'htmlall':'UTF-8'}">
     </div>
 {literal}
-    <script type="text/javascript"  src="https://cdn.divido.com/widget/v3/{/literal}{$finance_environment|escape:'htmlall':'UTF-8'}{literal}.calculator.js" ></script>
+    <script type="text/javascript"  src="{/literal}{$calculator_url}{literal}" ></script>
 {/literal}
 <div class="buttons">
     <p class="cart_navigation clearfix">

--- a/financepayment/views/templates/front/payment_execution_1_6.tpl
+++ b/financepayment/views/templates/front/payment_execution_1_6.tpl
@@ -60,7 +60,7 @@
     <div data-calculator-widget data-mode="calculator" data-amount="{$raw_total *100|escape:'htmlall':'UTF-8'}" data-plans="{$plans|escape:'htmlall':'UTF-8'}">
 </div>
 {literal}
-    <script type="text/javascript"  src="https://cdn.divido.com/widget/v3/{/literal}{$finance_environment|escape:'htmlall':'UTF-8'}{literal}.calculator.js" ></script>
+    <script type="text/javascript"  src="{/literal}{$calculator_url}{literal}" ></script>
 {/literal}
 
     <div class="buttons">

--- a/financepayment/views/templates/hook/calculator.tpl
+++ b/financepayment/views/templates/hook/calculator.tpl
@@ -33,5 +33,5 @@
 {/literal}
 <div data-calculator-widget data-amount="{$raw_total*100|escape:'htmlall':'UTF-8'}"  data-plans="{$plans|escape:'htmlall':'UTF-8'}"></div>
 {literal}
-    <script type="text/javascript"  src="https://cdn.divido.com/widget/v3/{/literal}{$finance_environment|escape:'htmlall':'UTF-8'}{literal}.calculator.js" ></script>
+    <script type="text/javascript"  src="{/literal}{$calculator_url}{literal}" ></script>
 {/literal}

--- a/financepayment/views/templates/hook/widget.tpl
+++ b/financepayment/views/templates/hook/widget.tpl
@@ -45,7 +45,7 @@
     {if $data_language}data-language="{$data_language}"{/if}
 ></div>
 {literal}
-    <script type="text/javascript"  src="https://cdn.divido.com/widget/v3/{/literal}{$finance_environment|escape:'htmlall':'UTF-8'}{literal}.calculator.js" ></script>
+    <script type="text/javascript"  src="{/literal}{$calculator_url}{literal}" ></script>
 {/literal}
 
 


### PR DESCRIPTION
- introduces a function to choose the calculator script
- Utilises the existing getSDK function throughout the plugin
- Turns the Merchant_SDK class into a singleton
- Adds SKUs to product items in application (required by ING)
- Catches an error caused by UAT not having a default Divido merchant API URL
- Creates single source of truth for plugin version