### PR TITLE
chore: catches nordea api keys and displays logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,3 +67,6 @@ All notable changes to this project will be documented in this file.
 
 ## [2.3.3] - 2022-01-20
 - Chore: Updated the readme file
+
+## [2.3.4] - 2022-06-10
+- Chore: Adds nordea logo to checkout

--- a/financepayment/classes/DividoHelper.php
+++ b/financepayment/classes/DividoHelper.php
@@ -10,7 +10,7 @@ class DividoHelper
 {
     const CALCULATOR_URL = "//cdn.divido.com/widget/v3/";
 
-    const PLUGIN_VERSION = "2.3.3";
+    const PLUGIN_VERSION = "2.3.4";
 
     public static function generateCalcUrl($tenant, $environment){
 

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -864,7 +864,7 @@ class FinancePayment extends PaymentModule
         $newOption = new PrestaShop\PrestaShop\Core\Payment\PaymentOption;
         $newOption->setCallToActionText($action);
         if($env === 'nordea'){
-            $newOption->setLogo('https://cdn.divido.com/widge/themes/nordea/logo-presta.png');
+            $newOption->setLogo('https://s3.eu-west-1.amazonaws.com/content.divido.com/widget/themes/nordea/nordea-presta.png');
         }
         $newOption->setAction($this->context->link->getModuleLink($this->name, 'payment', array(), true));
         $newOption->setAdditionalInformation($info);

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -856,10 +856,16 @@ class FinancePayment extends PaymentModule
             return;
         }
 
+        $api = new FinanceApi();
+        $env = $api->getFinanceEnv(Configuration::get('FINANCE_API_KEY'));
+
         $action = Configuration::get('FINANCE_PAYMENT_TITLE');
         $info = Configuration::get('FINANCE_PAYMENT_DESCRIPTION');
         $newOption = new PrestaShop\PrestaShop\Core\Payment\PaymentOption;
         $newOption->setCallToActionText($action);
+        if($env === 'nordea'){
+            $newOption->setLogo('https://cdn.divido.com/widge/themes/nordea/logo-presta.png');
+        }
         $newOption->setAction($this->context->link->getModuleLink($this->name, 'payment', array(), true));
         $newOption->setAdditionalInformation($info);
         $payment_options = array($newOption);


### PR DESCRIPTION
Adds the Nordea logo to checkout if API Key belongs to a nordea merchant

### PR CHECKLIST

- [ ] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [ ] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [ ] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
