### PR TITLE
chore: fix merchant sdk to v2.5.1

### DIFF
--- a/financepayment/classes/DividoHelper.php
+++ b/financepayment/classes/DividoHelper.php
@@ -10,7 +10,7 @@ class DividoHelper
 {
     const CALCULATOR_URL = "//cdn.divido.com/widget/v3/";
 
-    const PLUGIN_VERSION = "2.3.4";
+    const PLUGIN_VERSION = "2.3.5";
 
     public static function generateCalcUrl($tenant, $environment){
 

--- a/financepayment/composer.json
+++ b/financepayment/composer.json
@@ -4,7 +4,7 @@
     },
     "require": {
         "php": ">=5",
-        "divido/merchant-sdk":"^2.5.0",
+        "divido/merchant-sdk":"2.5.1",
         "divido/merchant-sdk-guzzle-5": "^1.2.0"
     }
 }


### PR DESCRIPTION
As we introduce a breaking change to the merchant SDK, we ensure existing implementations don't update the version until the implementation has been adapted to the new version

### PR CHECKLIST

- [x] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [x] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [x] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
