### PR TITLE
fix: guzzle rollback

### DIFF
--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -24,7 +24,11 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
+use Divido\MerchantSDKGuzzle5\GuzzleAdapter;
 use Divido\MerchantSDK\Client;
+use Divido\MerchantSDK\Environment;
+use Divido\MerchantSDK\HttpClient\HttpClientWrapper;
+use GuzzleHttp\Client as Guzzle;
 
 class FinanceApi
 {
@@ -84,9 +88,11 @@ class FinanceApi
             return array();
         }
 
+        $client = new Guzzle();
         $env = $this->getEnvironment($api_key);
 
-        $httpClientWrapper = new \Divido\MerchantSDK\Wrappers\HttpWrapper(
+        $httpClientWrapper = new HttpClientWrapper(
+            new GuzzleAdapter($client),
             self::CONFIGURATION[$env]['base_uri'],
             $api_key
         );
@@ -232,8 +238,10 @@ class FinanceApi
             return array();
         }
 
+        $client = new Guzzle();
         $env = $this->getEnvironment($api_key);
-        $httpClientWrapper = new \Divido\MerchantSDK\Wrappers\HttpWrapper(
+        $httpClientWrapper = new HttpClientWrapper(
+            new GuzzleAdapter($client),
             self::CONFIGURATION[$env]['base_uri'],
             $api_key
         );

--- a/financepayment/composer.json
+++ b/financepayment/composer.json
@@ -4,6 +4,7 @@
     },
     "require": {
         "php": ">=5",
-        "divido/merchant-sdk":"^3.0.1"
+        "divido/merchant-sdk":"v2.1.1",
+        "divido/merchant-sdk-guzzle-5": "v1.1.0"
     }
 }

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -31,6 +31,7 @@ if (!defined('_PS_VERSION_')) {
 require_once dirname(__FILE__) . '/vendor/autoload.php';
 require_once dirname(__FILE__) . '/classes/divido.class.php';
 
+use Divido\MerchantSDKGuzzle5\GuzzleAdapter;
 use Divido\MerchantSDK\HttpClient\HttpClientWrapper;
 
 class FinancePayment extends PaymentModule
@@ -78,7 +79,7 @@ class FinancePayment extends PaymentModule
     {
         $this->name = 'financepayment';
         $this->tab = 'payments_gateways';
-        $this->version = 'ING-v.1.3.4';
+        $this->version = 'ING-v.1.3.5';
         $this->author = 'Divido Financial Services Ltd';
         $this->need_instance = 0;
         $this->module_key = "71b50f7f5d75c244cd0a5635f664cd56";


### PR DESCRIPTION
Rolls back Merchant API SDK bump

### PR CHECKLIST

- [ ] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [ ] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [ ] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
