### PR TITLE
fix: implement latest MerchantApiSdk everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,3 +62,8 @@ All notable changes to this project will be documented in this file.
 ## [ING-v.1.3.4] - 2023-01-12
 - Feat: Adds ING logo to checkout
 - Feat: Bumps Merchant API SDK version
+
+## [ING-v.1.3.5] - 2023-01-15
+- Fix: Implements new Merchant API SDK everywhere
+- Fix: Leaves response client to discovery
+- Fix: Solid Guzzle version requirement for Prestashop compatibility

--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -84,7 +84,7 @@ class FinanceApi
             return array();
         }
 
-        $env = $this->getEnvironment($api_key);
+        $env = FinanceApi::getEnvironment($api_key);
 
         $httpClientWrapper = new \Divido\MerchantSDK\Wrappers\HttpWrapper(
             self::CONFIGURATION[$env]['base_uri'],
@@ -205,7 +205,7 @@ class FinanceApi
     }
 
 
-    public function getEnvironment($key)
+    public static function getEnvironment($key)
     {
         $array       = explode('_', $key);
         $environment = Tools::strtoupper($array[0]);
@@ -232,7 +232,7 @@ class FinanceApi
             return array();
         }
 
-        $env = $this->getEnvironment($api_key);
+        $env = FinanceApi::getEnvironment($api_key);
         $httpClientWrapper = new \Divido\MerchantSDK\Wrappers\HttpWrapper(
             self::CONFIGURATION[$env]['base_uri'],
             $api_key

--- a/financepayment/composer.json
+++ b/financepayment/composer.json
@@ -4,6 +4,7 @@
     },
     "require": {
         "php": ">=5",
-        "divido/merchant-sdk":"^3.0.1"
+        "divido/merchant-sdk":"^3.0.1",
+        "guzzlehttp/guzzle": "^6.5.8"
     }
 }

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -24,9 +24,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
-
+use Http\Discovery\HttpClientDiscovery;
 class FinancePaymentResponseModuleFrontController extends ModuleFrontController
 {
     const DEBUG_MODE = true;
@@ -735,7 +733,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
         $env = FinanceApi::getEnvironment($api_key);
         $base_uri = FinanceApi::CONFIGURATION[$env]['base_uri'];
 
-        $client = new Client();
+        $client = new HttpClientDiscovery::find();
         $url = "{$base_uri}/applications/{$application_id}";
         $body = [
             "id" => $application_id,
@@ -753,7 +751,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
                 'allow_redirects' => false,
                 'timeout'         => 5
             ]);
-        } catch (RequestException $e) {
+        } catch (\Exception $e) {
             PrestaShopLogger::addLog(
                 $e->getResponse(),
                 1,

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -24,11 +24,7 @@
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
-use Divido\MerchantSDKGuzzle5\GuzzleAdapter;
 use Divido\MerchantSDK\Client;
-use Divido\MerchantSDK\Environment;
-use Divido\MerchantSDK\HttpClient\HttpClientWrapper;
-use GuzzleHttp\Client as Guzzle;
 
 class FinancePaymentValidationModuleFrontController extends ModuleFrontController
 {
@@ -245,9 +241,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
         );
 //Note: If creating an application on a merchant with a shared secret, you will have to pass in a valid hmac
                 $env = FinanceApi::getEnvironment($api_key);
-                $client = new Guzzle();
-                $httpClientWrapper = new HttpClientWrapper(
-                    new GuzzleAdapter($client),
+                $httpClientWrapper = new \Divido\MerchantSDK\Wrappers\HttpWrapper(
                     FinanceApi::CONFIGURATION[$env]['base_uri'],
                     $api_key
                 );

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -31,8 +31,6 @@ if (!defined('_PS_VERSION_')) {
 require_once dirname(__FILE__) . '/vendor/autoload.php';
 require_once dirname(__FILE__) . '/classes/divido.class.php';
 
-use Divido\MerchantSDK\HttpClient\HttpClientWrapper;
-
 class FinancePayment extends PaymentModule
 {
     public $ps_below_7;
@@ -1101,14 +1099,12 @@ class FinancePayment extends PaymentModule
             ->withTrackingNumber($tracking_numbers);
         // Create a new activation for the application.
         $env = FinanceApi::getEnvironment($api_key);
-        $client = new \GuzzleHttp\Client();
-        $httpClientWrapper = new HttpClientWrapper(
-            new GuzzleAdapter($client),
+        $httpClientWrapper = new \Divido\MerchantSDK\Wrappers\HttpWrapper(
             FinanceApi::CONFIGURATION[$env]['base_uri'],
             $api_key
         );
-        $sdk                      = new \Divido\MerchantSDK\Client($httpClientWrapper, $env);
-        $response                 = $sdk->applicationActivations()->createApplicationActivation(
+        $sdk = new \Divido\MerchantSDK\Client($httpClientWrapper, $env);
+        $response = $sdk->applicationActivations()->createApplicationActivation(
             $application,
             $application_activation
         );
@@ -1158,10 +1154,8 @@ class FinancePayment extends PaymentModule
         $applicationCancel = ( new \Divido\MerchantSDK\Models\ApplicationCancellation() )
             ->withOrderItems($items);
         // Create a new activation for the application.
-        $env                      = FinanceApi::getEnvironment($api_key);
-        $client                   = new \GuzzleHttp\Client();
-        $httpClientWrapper        = new HttpClientWrapper(
-            new GuzzleAdapter($client),
+        $env = FinanceApi::getEnvironment($api_key);
+        $httpClientWrapper = new \Divido\MerchantSDK\Wrappers\HttpWrapper(
             FinanceApi::CONFIGURATION[$env]['base_uri'],
             $api_key
         );
@@ -1214,9 +1208,8 @@ class FinancePayment extends PaymentModule
             ->withOrderItems($items);
         // Create a new activation for the application.
         $env                      = FinanceApi::getEnvironment($api_key);
-        $client                   = new \GuzzleHttp\Client();
-        $httpClientWrapper        = new HttpClientWrapper(
-            new GuzzleAdapter($client),
+        
+        $httpClientWrapper = new \Divido\MerchantSDK\Wrappers\HttpWrapper(
             FinanceApi::CONFIGURATION[$env]['base_uri'],
             $api_key
         );

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -76,7 +76,7 @@ class FinancePayment extends PaymentModule
     {
         $this->name = 'financepayment';
         $this->tab = 'payments_gateways';
-        $this->version = 'ING-v.1.3.4';
+        $this->version = 'ING-v.1.3.5';
         $this->author = 'Divido Financial Services Ltd';
         $this->need_instance = 0;
         $this->module_key = "71b50f7f5d75c244cd0a5635f664cd56";
@@ -1207,7 +1207,7 @@ class FinancePayment extends PaymentModule
         $applicationRefund = ( new \Divido\MerchantSDK\Models\ApplicationRefund() )
             ->withOrderItems($items);
         // Create a new activation for the application.
-        $env                      = FinanceApi::getEnvironment($api_key);
+        $env = FinanceApi::getEnvironment($api_key);
         
         $httpClientWrapper = new \Divido\MerchantSDK\Wrappers\HttpWrapper(
             FinanceApi::CONFIGURATION[$env]['base_uri'],


### PR DESCRIPTION
- Implements the new Merchant API SDK for cancellations/refunds and activations too
- Uses Discovery for Client in Webhook responses
- Requires Guzzle 6.5.8 for Prestashop compatibility

### PR CHECKLIST

- [x] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [x] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [x] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
