### PR TITLE
fix: remove use of Tools class for standard functions

### DIFF
--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -220,7 +220,7 @@ class FinanceApi
         }
         return ('LIVE' == $environment)
             ? "production"
-            : Tools::strtolower($environment);
+            : strtolower($environment);
     }
 
 

--- a/financepayment/controllers/front/payment.php
+++ b/financepayment/controllers/front/payment.php
@@ -90,7 +90,7 @@ class FinancePaymentPaymentModuleFrontController extends ModuleFrontController
                 'merchant_script' => "//cdn.divido.com/calculator/".$js_key.".js",
                 'plans' => implode(',', array_keys($plans)),
                 'validationLink' => $this->context->link->getModuleLink('financepayment', 'validation'),
-                'api_key' => Tools::substr(
+                'api_key' => substr(
                     Configuration::get('FINANCE_API_KEY'),
                     0,
                     strpos(Configuration::get('FINANCE_API_KEY'), ".")

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -35,8 +35,8 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
 
     public function postProcess()
     {
-        $input = Tools::file_get_contents('php://input');
-        $data  = Tools::jsonDecode($input);
+        $input = file_get_contents('php://input');
+        $data  = json_decode($input);
         $callback_sign = isset($_SERVER['HTTP_X_DIVIDO_HMAC_SHA256']) ?  $_SERVER['HTTP_X_DIVIDO_HMAC_SHA256']  : null;
         $secret = null;
 
@@ -561,7 +561,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
                 '{carrier}' => (
                     $virtual_product || !isset($carrier->name)
                 ) ? $this->module->l('no_carrier') : $carrier->name,
-                '{payment}' => Tools::substr($order->payment, 0, 255),
+                '{payment}' => substr($order->payment, 0, 255),
                 '{products}' => $product_list_html,
                 '{products_txt}' => $product_list_txt,
                 '{discounts}' => $cart_rules_list_html,

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -54,7 +54,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
          * If the module is not active anymore, no need to process anything.
          */
         if ($this->module->active == false) {
-            echo Tools::jsonEncode($response);
+            echo json_encode($response);
             die;
         }
 
@@ -65,12 +65,12 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
                 'status' => true,
                 'url' => $this->context->link->getPageLink('order'),
             );
-            echo Tools::jsonEncode($response);
+            echo json_encode($response);
             die;
         }
 
         if (!Validate::isLoadedObject($cart)) {
-            echo Tools::jsonEncode($response);
+            echo json_encode($response);
             die;
         }
 
@@ -78,7 +78,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
 
         $id_add = $cart->id_address_delivery;
         if ($id_cus == 0 || $id_add == 0 || $cart->id_address_invoice == 0) {
-            echo Tools::jsonEncode($response);
+            echo json_encode($response);
             die;
         }
 
@@ -96,7 +96,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
         }
 
         $response = $this->getConfirmation();
-        echo Tools::jsonEncode($response);
+        echo json_encode($response);
         die;
     }
 

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -672,7 +672,7 @@ class FinancePayment extends PaymentModule
     {
         $api_key   = Configuration::get('FINANCE_API_KEY');
         $key_parts = explode('.', $api_key);
-        $js_key    = Tools::strtolower(array_shift($key_parts));
+        $js_key    = strtolower(array_shift($key_parts));
         return $js_key;
     }
 
@@ -1044,7 +1044,7 @@ class FinancePayment extends PaymentModule
             'raw_total' => $product_price,
             'finance_environment'  => Configuration::get('FINANCE_ENVIRONMENT'),
             'calculator_url' => $calculator_url,
-            'api_key' => Tools::substr(
+            'api_key' => substr(
                 Configuration::get('FINANCE_API_KEY'),
                 0,
                 strpos(Configuration::get('FINANCE_API_KEY'), ".")


### PR DESCRIPTION
Removes all use of Tools class wrapping standard php functions 

### PR CHECKLIST

- [x] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [x] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [x] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
