### PR TITLE
chore: bumps the version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,3 +67,6 @@ All notable changes to this project will be documented in this file.
 - Fix: Implements new Merchant API SDK everywhere
 - Fix: Leaves response client to discovery
 - Fix: Solid Guzzle version requirement for Prestashop compatibility
+
+## [ING-v.1.3.6] - 2023-01-18
+- Fix: Removes unnecessary use of Tools class

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -76,7 +76,7 @@ class FinancePayment extends PaymentModule
     {
         $this->name = 'financepayment';
         $this->tab = 'payments_gateways';
-        $this->version = 'ING-v.1.3.5';
+        $this->version = 'ING-v.1.3.6';
         $this->author = 'Divido Financial Services Ltd';
         $this->need_instance = 0;
         $this->module_key = "71b50f7f5d75c244cd0a5635f664cd56";


### PR DESCRIPTION
Realigns the versions

### PR CHECKLIST

- [ ] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [x] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [ ] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
