### PR TITLE
feat: LM2-1285 lender branding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/
 vendor/
 financepayment.zip
+financepayment/composer.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,3 +73,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.4.0] - 2022-12-12
 - Feat: Bumps the Merchant API SDK to the latest version
+
+## [2.5.0] - 2023-01-25
+- Feat: Attempts to retrieve the lender logo to display at checkout
+- Fix: Solves issues relating to use of Prestashop's Tools class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,3 +77,4 @@ All notable changes to this project will be documented in this file.
 ## [2.5.0] - 2023-01-25
 - Feat: Attempts to retrieve the lender logo to display at checkout
 - Fix: Solves issues relating to use of Prestashop's Tools class
+- Fix: Handles calculator deposit amount correctly

--- a/financepayment/.gitignore
+++ b/financepayment/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /vendor
 .php_cs.cache
+/checkout.png

--- a/financepayment/.gitignore
+++ b/financepayment/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 .php_cs.cache
 /checkout.png
+/composer.lock

--- a/financepayment/classes/DividoHelper.php
+++ b/financepayment/classes/DividoHelper.php
@@ -10,7 +10,7 @@ class DividoHelper
 {
     const CALCULATOR_URL = "//cdn.divido.com/widget/v3/";
 
-    const PLUGIN_VERSION = "2.4.0";
+    const PLUGIN_VERSION = "2.5.0";
 
     public static function generateCalcUrl($tenant, $environment){
 

--- a/financepayment/classes/divido.class.php
+++ b/financepayment/classes/divido.class.php
@@ -183,6 +183,7 @@ class FinanceApi
                 $plan_copy->interest_rate = $plan->interest_rate_percentage;
                 $plan_copy->deferral_period = $plan->deferral_period_months;
                 $plan_copy->agreement_duration = $plan->agreement_duration_months;
+                $plan_copy->branding = $plan->lender->branding ?? (object)[];
                 if($plan->active){
                     $plans_plain[$plan->id] = $plan_copy;
                 }

--- a/financepayment/composer.json
+++ b/financepayment/composer.json
@@ -4,6 +4,7 @@
     },
     "require": {
         "php": ">=5",
-        "divido/merchant-sdk":"^3.0.1"
+        "divido/merchant-sdk":"^3.0.1",
+        "guzzlehttp/guzzle": "^6.5.8"
     }
 }

--- a/financepayment/controllers/front/payment.php
+++ b/financepayment/controllers/front/payment.php
@@ -85,7 +85,7 @@ class FinancePaymentPaymentModuleFrontController extends ModuleFrontController
                 'merchant_script' => "//cdn.divido.com/calculator/".$js_key.".js",
                 'plans' => implode(',', array_keys($plans)),
                 'validationLink' => $this->context->link->getModuleLink('financepayment', 'validation'),
-                'api_key' => Tools::substr(
+                'api_key' => substr(
                     Configuration::get('FINANCE_API_KEY'),
                     0,
                     strpos(Configuration::get('FINANCE_API_KEY'), ".")

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -32,8 +32,8 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
 
     public function postProcess()
     {
-        $input = Tools::file_get_contents('php://input');
-        $data  = Tools::jsonDecode($input);
+        $input = file_get_contents('php://input');
+        $data  = json_decode($input);
         $callback_sign = isset($_SERVER['HTTP_X_DIVIDO_HMAC_SHA256']) ?  $_SERVER['HTTP_X_DIVIDO_HMAC_SHA256']  : null;
         $secret = null;
 
@@ -309,7 +309,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
                 unset($voucher->id);
 
                 // Set a new voucher code
-                $voucher->code = empty($voucher->code) ? Tools::substr(
+                $voucher->code = empty($voucher->code) ? substr(
                     md5($order->id.'-'.$order->id_customer.'-'.$cart_rule['obj']->id),
                     0,
                     16
@@ -508,7 +508,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
                 '{carrier}' => (
                     $virtual_product || !isset($carrier->name)
                 ) ? $this->module->l('no_carrier') : $carrier->name,
-                '{payment}' => Tools::substr($order->payment, 0, 255),
+                '{payment}' => substr($order->payment, 0, 255),
                 '{products}' => $product_list_html,
                 '{products_txt}' => $product_list_txt,
                 '{discounts}' => $cart_rules_list_html,

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -103,7 +103,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
     {
         $this->context = Context::getContext();
         $api_key   = Configuration::get('FINANCE_API_KEY');
-        $deposit = round(Tools::getValue('deposit'));
+        $deposit = (int) Tools::getValue('deposit');
         $finance = Tools::getValue('finance');
         $cart = $this->context->cart;
 

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -53,7 +53,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
          * If the module is not active anymore, no need to process anything.
          */
         if ($this->module->active == false) {
-            echo Tools::jsonEncode($response);
+            echo json_encode($response);
             die;
         }
 
@@ -64,19 +64,19 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
                 'status' => true,
                 'url' => $this->context->link->getPageLink('order'),
             );
-            echo Tools::jsonEncode($response);
+            echo json_encode($response);
             die;
         }
 
         if (!Validate::isLoadedObject($cart)) {
-            echo Tools::jsonEncode($response);
+            echo json_encode($response);
             die;
         }
 
         $id_cus = $cart->id_customer;
         $id_add = $cart->id_address_delivery;
         if ($id_cus == 0 || $id_add == 0 || $cart->id_address_invoice == 0) {
-            echo Tools::jsonEncode($response);
+            echo json_encode($response);
             die;
         }
 
@@ -95,7 +95,7 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
         }
 
         $response = $this->getConfirmation();
-        echo Tools::jsonEncode($response);
+        echo json_encode($response);
         die;
     }
 

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -91,6 +91,10 @@ class FinancePayment extends PaymentModule
 
     const SUPPORTED_LANGUAGES = ['gb', 'no', 'fi', 'da', 'fr', 'es', 'pe', 'en', 'de'];
 
+    const LOGO_RESIZE_HEIGHT = 30;
+    const LOGO_PADDING = 2;
+    const CHECKOUT_LOGO = 'checkout.png';
+
     public function __construct()
     {
         $this->name = 'financepayment';
@@ -416,6 +420,20 @@ class FinancePayment extends PaymentModule
                 if ($financePlans === NULL) {
                     throw new NoFinancePlansException();
                 };
+
+                foreach($financePlans as $plan){
+                    if(!empty($plan->branding->logo_url)){
+                        try{
+                            $this->resizeLogo($plan->branding->logo_url);
+                            break;
+                        } catch (\Exception $e) {
+                            echo($e->getMessage());
+                            PrestaShopLogger::addLog(
+                                sprintf('Failed to create image from %s: %s', $plan->branding->logo_url, $e->getMessage())
+                            );
+                        }
+                    }
+                }
 
                 $orderStatus = OrderState::getOrderStates($this->context->language->id);
                 $product_options = array(
@@ -864,7 +882,11 @@ class FinancePayment extends PaymentModule
         $newOption = new PrestaShop\PrestaShop\Core\Payment\PaymentOption;
         $newOption->setCallToActionText($action);
         
-        $this->setLogo($newOption, $plans);
+        if(file_exists(sprintf('%s/%s',__DIR__, FinancePayment::CHECKOUT_LOGO))){
+            $newOption->setLogo(
+                sprintf("%s/modules/financepayment/%s", _PS_BASE_URL_, FinancePayment::CHECKOUT_LOGO)
+            );
+        }
         
         $newOption->setAction($this->context->link->getModuleLink($this->name, 'payment', array(), true));
         $newOption->setAdditionalInformation($info);
@@ -1254,15 +1276,36 @@ class FinancePayment extends PaymentModule
         return $plans;
     }
 
-    private function setLogo(
-        PrestaShop\PrestaShop\Core\Payment\PaymentOption $paymentOption, 
-        array $plans
-    ){
-        foreach($plans as $plan){
-            if(!empty($plan->lender->branding->logoUrl)){
-                $paymentOption->setLogo($plan->lender->branding->logoUrl);
-                break;
-            }
+    private function resizeLogo(string $url){
+        $source = @imagecreatefromstring(file_get_contents($url));
+        if(!$source){
+            throw new \Exception("image type is unsupported, the data is not in a recognised format, or the image is corrupt and cannot be loaded.");
         }
+        list($originalWidth, $originalHeight) = getimagesize($url);
+        $newHeight = FinancePayment::LOGO_RESIZE_HEIGHT;
+        $factor = $newHeight/$originalHeight;
+        $newWidth = round($originalWidth*$factor);
+        $frameHeight = $newHeight + (FinancePayment::LOGO_PADDING*2);
+        $frameWidth = $newWidth + (FinancePayment::LOGO_PADDING*2);
+        $thumb = imagecreatetruecolor($frameWidth, $frameHeight);
+        imagealphablending($thumb, false);
+        imagesavealpha($thumb, true);
+        $transparent = imagecolorallocatealpha($thumb, 255, 255, 255, 127);
+        imagefilledrectangle($thumb, 0, 0, $frameWidth, $frameHeight, $transparent);
+        imagecopyresampled(
+            $thumb, 
+            $source, 
+            FinancePayment::LOGO_PADDING, 
+            FinancePayment::LOGO_PADDING, 
+            0, 
+            0, 
+            $newWidth, 
+            $newHeight, 
+            $originalWidth, 
+            $originalHeight
+        );
+        $filename = FinancePayment::CHECKOUT_LOGO;
+        imagepng($thumb, __DIR__.'/'.$filename, 0);
+        return $filename;
     }
 }

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -863,9 +863,9 @@ class FinancePayment extends PaymentModule
         $info = Configuration::get('FINANCE_PAYMENT_DESCRIPTION');
         $newOption = new PrestaShop\PrestaShop\Core\Payment\PaymentOption;
         $newOption->setCallToActionText($action);
-        if($env === 'nordea'){
-            $newOption->setLogo('https://s3.eu-west-1.amazonaws.com/content.divido.com/widget/themes/nordea/nordea-presta.png');
-        }
+        
+        $this->setLogo($newOption, $plans);
+        
         $newOption->setAction($this->context->link->getModuleLink($this->name, 'payment', array(), true));
         $newOption->setAdditionalInformation($info);
         $payment_options = array($newOption);
@@ -1252,5 +1252,17 @@ class FinancePayment extends PaymentModule
         $plans  = $FinanceApi->getPlans();
 
         return $plans;
+    }
+
+    private function setLogo(
+        PrestaShop\PrestaShop\Core\Payment\PaymentOption $paymentOption, 
+        array $plans
+    ){
+        foreach($plans as $plan){
+            if(!empty($plan->lender->branding->logoUrl)){
+                $paymentOption->setLogo($plan->lender->branding->logoUrl);
+                break;
+            }
+        }
     }
 }

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -1305,7 +1305,10 @@ class FinancePayment extends PaymentModule
             $originalHeight
         );
         $filename = FinancePayment::CHECKOUT_LOGO;
-        imagepng($thumb, __DIR__.'/'.$filename, 0);
+        $created = imagepng($thumb, __DIR__.'/'.$filename, 0);
+        if(!$created){
+            throw new \exception("Could not create a png from the image");
+        }
         return $filename;
     }
 }

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -770,7 +770,7 @@ class FinancePayment extends PaymentModule
     {
         $api_key   = Configuration::get('FINANCE_API_KEY');
         $key_parts = explode('.', $api_key);
-        $js_key    = Tools::strtolower(array_shift($key_parts));
+        $js_key    = strtolower(array_shift($key_parts));
 
         return $js_key;
     }

--- a/financepayment/views/js/finance.js
+++ b/financepayment/views/js/finance.js
@@ -30,7 +30,7 @@ $(document).on(
 
         var finance_elem = $('input[name="divido_plan"]');
         var total = $('input[name="divido_total"]').val();
-        var deposit = Math.round($('input[name="divido_deposit"]').val());
+        var deposit = $('input[name="divido_deposit"]').val() || 0;
 
         var finance;
         if (finance_elem.length > 0) {


### PR DESCRIPTION
This PR retrieves the lender branding logo from the finance plans related to the current API Key every time the merchant goes to the plugin's control panel, and attempts to generate a smaller copy of the image for use in the Prestashop checkout. This is because Prestashop will just display the logo as it receives it in the checkout, so the chances are the original logo will look massive in the checkout, as anything over 30px in height looks a bit ungainly.

Little caveat is that this PR can't handle SVG files. This is something we'll look to fix at a later date.

Additionally, this PR:
- Removes unnecessary uses of the Tools class for standard PHP functions
- Bumps the version of the Merchant API Pub SDK being used

### PR CHECKLIST

- [x] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [x] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [x] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
