### PR TITLE
chore/bump config

### DIFF
--- a/financepayment/composer.json
+++ b/financepayment/composer.json
@@ -7,6 +7,7 @@
     },
     "require": {
         "php": ">=5",
-        "divido/merchant-sdk":"^3.0.1"
+        "divido/merchant-sdk":"^3.0.1",
+        "php-http/message-factory": "^1.1"
     }
 }

--- a/financepayment/config.xml
+++ b/financepayment/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>financepayment</name>
     <displayName><![CDATA[Powered by Divido]]></displayName>
-    <version><![CDATA[2.4.2]]></version>
+    <version><![CDATA[2.6.0]]></version>
     <description><![CDATA[The Finance extension allows you to accept finance payments in your Prestashop store.]]></description>
     <author><![CDATA[Divido Financial Services Ltd]]></author>
     <tab><![CDATA[payments_gateways]]></tab>


### PR DESCRIPTION
Yep, going to have to revert to using the `php-http/message-factory`. Not entirely sure why, but I think it's to support the psr-7 Guzzle/Nyholm implementation Prestashop uses, omitting it winds up with the following issue:

> No php-http message factories found. Note that the php-http message factories are deprecated in favor of the PSR-17 message factories. To use the legacy Guzzle, Diactoros or Slim Framework factories of php-http, install php-http/message and php-http/message and php-http/message-factory and the chosen message implementation.

Bearing in mind the `merchant-sdk` (a requirement of the plugin) requires the recommended PSR-17 alternative to `php-http/message-factory` (`psr/http-factory`), I can't think of another way.

### PR CHECKLIST

- [ ] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [ ] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [ ] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
