### PR TITLE
Chore/useful webhook responses

### DIFF
--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -552,7 +552,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
             }
 
             PrestaShopLogger::addLog(
-                'PaymentModule::validateOrder - Mail is about to be sent',
+                'FinancePaymentResponseModuleFrontController::updateOrder - Mail is about to be sent',
                 1,
                 null,
                 'Cart',

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -753,7 +753,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
 
         $storedCartHash = hash('sha256', $result['cart_id'].$result['hash']);
         if ($storedCartHash !== $webhookCartHash) {
-            throw new WebhookException("Cart Hash doesn't match expected ($storedCartHash)", self::HTTP_RESPONSE_CODE_UNAUTHORISED);
+            throw new WebhookException("Cart Hash doesn't match expected", self::HTTP_RESPONSE_CODE_UNAUTHORISED);
         }
 
         return $result;

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -34,7 +34,6 @@ use \Divido\Exceptions\WebhookException;
  */
 class FinancePaymentResponseModuleFrontController extends ModuleFrontController
 {
-    const DEBUG_MODE = true;
 
     const OK = 200;
     const CREATED = 201;

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -647,9 +647,13 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
      * @throws WebhookException if a required element of the payload is missing
      */
     private function validateWebhook(string $input):object{
-        $data  = json_decode($input);
-        if(!$data){
-            throw new WebhookException("Could not decode json payload of request", self::HTTP_RESPONSE_CODE_BAD_REQUEST);
+        try{
+            $data  = json_decode($input, false, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $je){
+            throw new WebhookException(
+                sprintf("Could not decode json payload of request: %s - %s", $je->getMessage(), json_last_error_msg()),
+                self::HTTP_RESPONSE_CODE_BAD_REQUEST
+            );
         }
 
         // only check HMAC if a secret is configured in the plugin config

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -61,11 +61,14 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
             $status = $this->convertStatus($data->status);
 
             $total = $cart->getOrderTotal();
-            if ($total != $request['total']) {
-                $status = Configuration::get('PS_OS_ERROR');
-            }
 
             $order = new Order(Order::getOrderByCartId($request['cart_id']));
+
+            if ($total != $request['total']) {
+                $this->setCurrentState($order, Configuration::get('PS_OS_ERROR'));
+                throw new WebhookException("Order total did not match total stored in db", self::INTERNAL_SERVER_ERROR);
+            }
+
             if ($status == $order->current_state) {
                 throw new WebhookException("Status Unchanged", self::OK);
             }

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -26,6 +26,9 @@ declare(strict_types=1);
 *  International Registered Trademark & Property of PrestaShop SA
 */
 
+/**
+ * The Response Controller handles webhooks sent by Divido
+ */
 class FinancePaymentResponseModuleFrontController extends ModuleFrontController
 {
     const DEBUG_MODE = true;

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -75,7 +75,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
             return;
         }
         
-        if ($order->current_state === Configuration::get('FINANCE_AWAITING_STATUS')) {
+        if ($status === Configuration::get('PS_OS_PAYMENT')) {
             
             $order->addOrderPayment($request['total'], null, $data->application);
             $this->setCurrentState($order, $status);

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -651,7 +651,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
 
         // only check HMAC if a secret is configured in the plugin config
         if (!empty(Configuration::get('FINANCE_HMAC'))){
-            $callback_sign = isset($_SERVER['HTTP_X_DIVIDO_HMAC_SHA256']) ?  $_SERVER['HTTP_X_DIVIDO_HMAC_SHA256']  : null;
+            $callback_sign = $_SERVER['HTTP_X_DIVIDO_HMAC_SHA256'] ?? null;
             if(empty($callback_sign)){
                 throw new WebhookException("Module configuration expects a HMAC. None received", self::HTTP_RESPONSE_CODE_UNAUTHORISED);
             }

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -664,7 +664,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
     protected function convertStatus($webhookStatus){
         $prestaStatus = Configuration::get(sprintf('FINANCE_STATUS_%s', $webhookStatus));
         if(!$prestaStatus){
-            throw new WebhookException("Could not convert status to Prestashop status", self::INTERNAL_SERVER_ERROR);
+            throw new WebhookException("Status has no Prestashop compliment to convert to", self::OK);
         }
         return $prestaStatus;
     }

--- a/financepayment/exceptions/WebhookException.php
+++ b/financepayment/exceptions/WebhookException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Divido\Exceptions;
+
+
+class WebhookException extends \Exception{
+
+}

--- a/financepayment/financepayment.php
+++ b/financepayment/financepayment.php
@@ -31,6 +31,7 @@ if (!defined('_PS_VERSION_')) {
 require_once dirname(__FILE__) . '/vendor/autoload.php';
 require_once dirname(__FILE__) . '/classes/divido.class.php';
 require_once dirname(__FILE__) . '/classes/DividoHelper.php';
+require_once dirname(__FILE__) . '/exceptions/WebhookException.php';
 
 use Divido\MerchantSDK\Environment;
 use Divido\MerchantSDK\Exceptions\InvalidApiKeyFormatException;


### PR DESCRIPTION
Doing a little groundwork before delving into some of the _really_ nasty code in this plugin. This PR looks to actually respond to webhooks with a useful response message, and a more relevant http code (rather than just die), as well as giving it a bit of refactor so it's a bit more orderly. I think this also might have helped me diagnose a fix for an issue we had with ING aeons ago, whereby we thought we were creating a race condition returning the customer before a payment has been created by the platform (triggered by the SIGNED webhook). I must have thought at the time that nobody was ~stupid~ complacent enough to not actually trigger the payment being created when the application is created, but [may have been incorrect in that assumption](https://github.com/dividohq/finance-plugin-prestashop/commit/f6a9575252e2b7c88eadb6cd3690e9360672ffb8).

### PR CHECKLIST

- [ ] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [ ] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [ ] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
