### PR TITLE
fix: ensure reference is int

### DIFF
--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -54,7 +54,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
         try{
             $data = $this->validateWebhook($input);
 
-            $cart = $this->retrieveCart($data->metadata->merchant_reference);
+            $cart = $this->retrieveCart((int) $data->metadata->merchant_reference);
 
             $initialOrder = $this->retrieveRequestFromDb(
                 $data->metadata->merchant_reference,
@@ -705,12 +705,12 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
     /**
      * Looks to retrieve the Cart object for the order with the merchant reference in the webhook metadata
      *
-     * @param string $merchantReference
+     * @param int $merchantReference The Prestashop Cart ID (int)
      * @return Cart
      * @throws WebhookException if Cart can not be loaded
      * @throws WebhookException if related Order does not exist for Cart object
      */
-    private function retrieveCart(string $merchantReference):Cart{
+    private function retrieveCart(int $merchantReference):Cart{
 
         $cart = new Cart($merchantReference);
         if (!Validate::isLoadedObject($cart)) {


### PR DESCRIPTION
Erk, the Cart ID (which we use for the Merchant Reference) is an integer. This changes the function within the response class to expect an integer and also ensures we give it an integer in case something funky happens in transit

### PR CHECKLIST

- [ ] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [ ] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [ ] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
