### PR TITLE
fix: merchant ref integer

### DIFF
--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -742,7 +742,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
         
         $result = Db::getInstance()->getRow(
             sprintf(
-                "SELECT * FROM `%sdivido_requests` WHERE `cart_id` = '%d'",
+                "SELECT * FROM `%sdivido_requests` WHERE `cart_id` = %d",
                 _DB_PREFIX_,
                 $merchantReference
             )

--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -57,7 +57,7 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
             $cart = $this->retrieveCart((int) $data->metadata->merchant_reference);
 
             $initialOrder = $this->retrieveRequestFromDb(
-                $data->metadata->merchant_reference,
+                (int) $data->metadata->merchant_reference,
                 $data->metadata->cart_hash
             );
 
@@ -729,20 +729,20 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
     /**
      * Retrieves snapshot of order taken at checkout
      *
-     * @param string $merchantReference The cart ID in the metadata, retrieved on application creation
+     * @param int $merchantReference The cart ID in the metadata, retrieved on application creation
      * @param string $webhookCartHash The cart hash in the metadata, assembled on proposal creation
      * @return array the table row
      * @throws WebhookException when row not found in db
      * @throws WebhookException if hash of cart does not match cart hash in webhook payload
      */
     private function retrieveRequestFromDb(
-        string $merchantReference,
+        int $merchantReference,
         string $webhookCartHash
     ):array{
         
         $result = Db::getInstance()->getRow(
             sprintf(
-                "SELECT * FROM `%sdivido_requests` WHERE `cart_id` = '%s'",
+                "SELECT * FROM `%sdivido_requests` WHERE `cart_id` = '%d'",
                 _DB_PREFIX_,
                 $merchantReference
             )


### PR DESCRIPTION
Same as https://github.com/dividohq/finance-plugin-prestashop/pull/76, but for the other function that uses the merchant ref

### PR CHECKLIST

- [ ] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [ ] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [ ] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
