### PR TITLE
chore: loosen return type

### DIFF
--- a/financepayment/controllers/front/response.php
+++ b/financepayment/controllers/front/response.php
@@ -691,15 +691,15 @@ class FinancePaymentResponseModuleFrontController extends ModuleFrontController
      * Converts the status of the divido status into the compliment status set in the FinancePayment->install() function
      *
      * @param string $webhookStatus the divido status
-     * @return int the prestashop compliment status
+     * @return mixed the prestashop compliment status
      * @throws WebhookException if compliment status does not exist 
      */
-    private function convertStatus(string $webhookStatus):int{
+    private function convertStatus(string $webhookStatus):mixed{
         $prestaStatus = Configuration::get(sprintf('FINANCE_STATUS_%s', $webhookStatus));
         if(!$prestaStatus){
             throw new WebhookException("Status has no Prestashop compliment to convert to", self::HTTP_RESPONSE_CODE_OK);
         }
-        return (int) $prestaStatus;
+        return $prestaStatus;
     }
 
     /**


### PR DESCRIPTION
Our convertStatus function returns an integer value, which kinda makes sense as we are retrieving an integer. Unfortunately Prestashop stores the status as a string, so when it comes to strictly comparing it to another status [here](https://github.com/dividohq/finance-plugin-prestashop/blob/f999364ced3052e9462d30108c0f461445b23dca/financepayment/controllers/front/response.php#L84), it fails. If I loosen this constraint in the function, we should always be comparing 🍎  to 🍎 , even if Prestashop decides to change how statuses are saved, as both sides of the comparison are using the same Configuration::get() method to retrieve the status.

### PR CHECKLIST

- [ ] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [ ] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [ ] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) has been updated
