### PR TITLE
feat: LM2-2243 shipping address

### DIFF
--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -110,19 +110,19 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
 
         $billingAddress = new Address($cart->id_address_invoice);
         $billingCountry = Country::getIsoById($billingAddress->id_country);
-        $billingAddressTextArr = [$billingAddress->address1];
-        if(!empty($billingAddress->address2)){
-            $billingAddressTextArr[] = $billingAddress->address2;
-        }
-        $billingAddressTextArr[] = $billingAddress->city;
+        $billingAddressTextArr = [
+            $billingAddress->address1,
+            $billingAddress->address2,
+            $billingAddress->city
+        ];
 
         $shippingAddress = new Address($cart->id_address_delivery);
         $shippingCountry = Country::getIsoById($shippingAddress->id_country);
-        $shippingAddressTextArr = [$shippingAddress->address1];
-        if(!empty($shippingAddress->address2)){
-            $shippingAddressTextArr[] = $shippingAddress->address2;
-        }
-        $shippingAddressTextArr[] = $shippingAddress->city;
+        $shippingAddressTextArr = [
+            $shippingAddress->address1,
+            $shippingAddress->address2,
+            $shippingAddress->city
+        ];
 
         if (gettype($this->context->language)==="integer") {
             $language = Language::getIsoById($this->context->language);
@@ -198,14 +198,13 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
                     array(
                         'postcode' => $billingAddress->postcode,
                         'country' => $billingCountry,
-                        'text' => implode(", ", $billingAddressTextArr)
-                             
+                        'text' => implode(", ", array_filter($billingAddressTextArr))
                     )
                 ),
                 'shippingAddress' => array(
                     'postcode' => $shippingAddress->postcode,
                     'country' => $shippingCountry,
-                    'text' => implode(", ", $shippingAddressTextArr)
+                    'text' => implode(", ", array_filter($shippingAddressTextArr))
                 )
             )
         );

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -103,16 +103,26 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
     {
         $this->context = Context::getContext();
         $api_key   = Configuration::get('FINANCE_API_KEY');
-        $deposit = (int) Tools::getValue('deposit');
+        $deposit = (int) Tools::getValue('deposit') ?? 0;
         $finance = Tools::getValue('finance');
         $cart = $this->context->cart;
         $customer = new Customer($cart->id_customer);
 
         $billingAddress = new Address($cart->id_address_invoice);
         $billingCountry = Country::getIsoById($billingAddress->id_country);
+        $billingAddressTextArr = [$billingAddress->address1];
+        if(!empty($billingAddress->address2)){
+            $billingAddressTextArr[] = $billingAddress->address2;
+        }
+        $billingAddressTextArr[] = $billingAddress->city;
 
         $shippingAddress = new Address($cart->id_address_delivery);
         $shippingCountry = Country::getIsoById($shippingAddress->id_country);
+        $shippingAddressTextArr = [$shippingAddress->address1];
+        if(!empty($shippingAddress->address2)){
+            $shippingAddressTextArr[] = $shippingAddress->address2;
+        }
+        $shippingAddressTextArr[] = $shippingAddress->city;
 
         if (gettype($this->context->language)==="integer") {
             $language = Language::getIsoById($this->context->language);
@@ -188,17 +198,18 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
                     array(
                         'postcode' => $billingAddress->postcode,
                         'country' => $billingCountry,
-                        'text' => sprintf("%s %s", $billingAddress->address1, $billingAddress->city)
+                        'text' => implode(", ", $billingAddressTextArr)
+                             
                     )
                 ),
                 'shippingAddress' => array(
                     'postcode' => $shippingAddress->postcode,
                     'country' => $shippingCountry,
-                    'text' => sprintf("%s %s", $shippingAddress->address1, $shippingAddress->city)
+                    'text' => implode(", ", $shippingAddressTextArr)
                 )
             )
         );
-        if(empty($billingAddress->phone)){
+        if(!empty($billingAddress->phone)){
             $applicant[0]['phoneNumber'] = $billingAddress->phone;
         }
 

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -202,37 +202,35 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
             $applicant[0]['phoneNumber'] = $billingAddress->phone;
         }
 
-        $application               = ( new \Divido\MerchantSDK\Models\Application() )
-        ->withCountryId($billingCountry)
-        ->withCurrencyId($currency)
-        ->withFinancePlanId($finance)
-        ->withApplicants(
-            $applicant
-        )
-        ->withOrderItems($products)
-        ->withDepositAmount($deposit)
-        ->withFinalisationRequired(false)
-        ->withMerchantReference((string) $cart_id)
-        ->withUrls(
-            array (
-                'merchant_redirect_url' => $redirect_url,
-                'merchant_checkout_url' => $checkout_url,
-                'merchant_response_url' => $response_url,
+        $application = ( new \Divido\MerchantSDK\Models\Application() )
+            ->withCountryId($billingCountry)
+            ->withCurrencyId($currency)
+            ->withFinancePlanId($finance)
+            ->withApplicants(
+                $applicant
             )
-        )
-        ->withMetadata(
-            array (
-                'cart_hash'    => $hash,
-                'ecom_platform' => 'prestashop',
-                'ecom_platform_version' => _PS_VERSION_,
-                'ecom_base_url'   => htmlspecialchars_decode($checkout_url),
-                'plugin_version'  => DividoHelper::getPluginVersion(),
-                'merchant_reference' => $cart_id
+            ->withOrderItems($products)
+            ->withDepositAmount($deposit)
+            ->withFinalisationRequired(false)
+            ->withMerchantReference((string) $cart_id)
+            ->withUrls(
+                array (
+                    'merchant_redirect_url' => $redirect_url,
+                    'merchant_checkout_url' => $checkout_url,
+                    'merchant_response_url' => $response_url,
+                )
             )
-        );
+            ->withMetadata(
+                array (
+                    'cart_hash'    => $hash,
+                    'ecom_platform' => 'prestashop',
+                    'ecom_platform_version' => _PS_VERSION_,
+                    'ecom_base_url'   => htmlspecialchars_decode($checkout_url),
+                    'plugin_version'  => DividoHelper::getPluginVersion(),
+                    'merchant_reference' => $cart_id
+                )
+            );
         //Note: If creating an application on a merchant with a shared secret, you will have to pass in a valid hmac
-var_dump($application->getJsonPayload());
-die();
         $sdk = Merchant_SDK::getSDK(Configuration::get('FINANCE_ENVIRONMENT_URL'), $api_key);
 
         $response = $sdk->applications()->createApplication(
@@ -242,25 +240,25 @@ die();
         );
 
         try {
-                $application_response_body = $response->getBody()->getContents();
-                $decode                    = json_decode($application_response_body);
-                $result_redirect           = $decode->data->urls->application_url;
-                $data = array(
-                    'status' => true,
-                    'url'    => $result_redirect,
-                );
-                    $customer = new Customer($cart->id_customer);
-                    $this->validatOrder(
-                        $cart_id,
-                        Configuration::get('FINANCE_AWAITING_STATUS'),
-                        $sub_total,
-                        $this->module->displayName,
-                        null,
-                        array('transaction_id' => $decode->data->id),
-                        (int) $cart->id_currency,
-                        false,
-                        $customer->secure_key
-                    );
+            $application_response_body = $response->getBody()->getContents();
+            $decode                    = json_decode($application_response_body);
+            $result_redirect           = $decode->data->urls->application_url;
+            $data = array(
+                'status' => true,
+                'url'    => $result_redirect,
+            );
+            $customer = new Customer($cart->id_customer);
+            $this->validatOrder(
+                $cart_id,
+                Configuration::get('FINANCE_AWAITING_STATUS'),
+                $sub_total,
+                $this->module->displayName,
+                null,
+                array('transaction_id' => $decode->data->id),
+                (int) $cart->id_currency,
+                false,
+                $customer->secure_key
+            );
         } catch (Exception $e) {
             $data = array(
                 'status'  => false,

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -182,35 +182,21 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
 
         $this->saveHash($cart_id, $salt, $sub_total);
 
+        $applicant = array(
+            array(
+                'firstName'   => $firstname,
+                'lastName'    => $lastname,
+                'email'       => $email,
+                'addresses'   => array(
+                    array(
+                        'postcode' => $postcode,
+                        'text'     => $postcode . " " . $address->address1 . " " . $address->city,
+                    ),
+                ),
+            ),
+        );
         if(empty($phone)){
-            $applicant = array(
-                array(
-                    'firstName'   => $firstname,
-                    'lastName'    => $lastname,
-                    'email'       => $email,
-                    'addresses'   => array(
-                        array(
-                            'postcode' => $postcode,
-                            'text'     => $postcode . " " . $address->address1 . " " . $address->city,
-                        ),
-                    ),
-                ),
-            );
-        } else {
-            $applicant = array(
-                array(
-                    'firstName'   => $firstname,
-                    'lastName'    => $lastname,
-                    'phoneNumber' => $phone,
-                    'email'       => $email,
-                    'addresses'   => array(
-                        array(
-                            'postcode' => $postcode,
-                            'text'     => $postcode . " " . $address->address1 . " " . $address->city,
-                        ),
-                    ),
-                ),
-            );
+            $applicant[0]['phoneNumber'] = $phone;
         }
 
         $application               = ( new \Divido\MerchantSDK\Models\Application() )

--- a/financepayment/controllers/front/validation.php
+++ b/financepayment/controllers/front/validation.php
@@ -127,12 +127,6 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
 
         $cart_id = $cart->id;
 
-        $firstname = $customer->firstname;
-        $lastname = $customer->lastname;
-        $email = $customer->email;
-        $postcode  = $address->postcode;
-        $phone = $address->phone;
-
         $products  = array();
         foreach ($cart->getProducts() as $product) {
             $reference = (empty($product['reference'])) ? $product['id_product'] : $product['reference'];
@@ -184,19 +178,19 @@ class FinancePaymentValidationModuleFrontController extends ModuleFrontControlle
 
         $applicant = array(
             array(
-                'firstName'   => $firstname,
-                'lastName'    => $lastname,
-                'email'       => $email,
+                'firstName'   => $customer->firstname,
+                'lastName'    => $customer->lastname,
+                'email'       => $customer->email,
                 'addresses'   => array(
                     array(
-                        'postcode' => $postcode,
-                        'text'     => $postcode . " " . $address->address1 . " " . $address->city,
-                    ),
-                ),
-            ),
+                        'postcode' => $address->postcode,
+                        'text'     => $address->address1 . " " . $address->city,
+                    )
+                )
+            )
         );
-        if(empty($phone)){
-            $applicant[0]['phoneNumber'] = $phone;
+        if(empty($address->phone)){
+            $applicant[0]['phoneNumber'] = $address->phone;
         }
 
         $application               = ( new \Divido\MerchantSDK\Models\Application() )


### PR DESCRIPTION
Adds a shipping address to the application request, in order to satisfy Oney requirements.

Restructures the address format to align with how the information is used in the `applicaiton-api`.

Also defaults deposit amount to 0 if empty, as we don't receive a deposit amount from the v4 calculator if it is 0.

### PR CHECKLIST

- [ ] All translations have been imported via the `make script-install-languages` command in [integrations-prestashop](https://github.com/dividohq/integrations-prestashop/blob/bc8d64ad55c25730878c29d1348f35eb5d30b9a5/Makefile#L39)
- [ ] The Changelog [CHANGELOG.md](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/CHANGELOG.md) has been updated with your proposed PR
- [ ] The plugin version at [financepayment/classes/DividoHelper.php](https://github.com/dividohq/finance-plugin-prestashop/blob/51294e4669ee1bcde7e2fe34659fc1c6bb539ba6/financepayment/classes/DividoHelper.php#L13) and at [financepayment/config.xml](https://github.com/dividohq/finance-plugin-prestashop/blob/f999364ced3052e9462d30108c0f461445b23dca/financepayment/config.xml#L5) has been updated
